### PR TITLE
fix constructor used in ECDSA-SHA256 algorithm

### DIFF
--- a/src/SWA/TokenBuilder.php
+++ b/src/SWA/TokenBuilder.php
@@ -61,7 +61,7 @@ final class TokenBuilder
         $issued_at = $this->issued_at ? $this->issued_at : time();
         $expiration = $this->expiration ? $this->expiration : ($issued_at + 3600);
 
-        $config = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText($this->private_key));
+        $config = Configuration::forSymmetricSigner(Sha256::create(), InMemory::plainText($this->private_key));
         return $config->builder()->withHeader('kid', $this->key_id)
             ->issuedBy($this->team_id)
             ->permittedFor('https://appleid.apple.com')


### PR DESCRIPTION
Fix ECDSA-SHA256 algorithm to use create() constructor.

When I call SWA\TokenBuilder#getClientSecret(), I get the following error message:
```php
TypeError: Too few arguments to function Lcobucci\JWT\Signer\Ecdsa::__construct(), 0 passed in /auth/vendor/ktakayama/swa/src/SWA/TokenBuilder.php on line 64 and exactly 1 expected
```

This error seems to be caused by not using the create() constructor with the ECDSA-SHA256 algorithm.
According to the official documentation:
```php
The implementation of ECDSA algorithms have a constructor dependency. Use the create() named constructor to avoid having to handle it (e.g.: Lcobucci\JWT\Signer\Ecdsa\Sha256::create()).
```
https://lcobucci-jwt.readthedocs.io/en/latest/configuration/#:~:text=arguments%20here%0A)%3B-,Important,-The%20implementation%20of